### PR TITLE
Convert application to BackgroundService to utilise Logging, DI and Configuration.

### DIFF
--- a/CDDABackup/BackupHandler.cs
+++ b/CDDABackup/BackupHandler.cs
@@ -40,14 +40,21 @@ namespace CDDABackup
         /// </summary>
         private readonly int timeBetweenUpdatesMilliseconds;
 
+        /// <summary>
+        /// Lookup for the last time a folder (the key) was modified (the value), used to control when to actually start making the backup
+        /// </summary>
         private Dictionary<string, DateTime> lastWritten = new Dictionary<string, DateTime>();
 
+        /// <summary>
+        /// The Application control so we can gracefully request shutdown via user input
+        /// </summary>
         private IHostApplicationLifetime hostApplicationLifetime;
 
         /// <summary>
         /// Creates a new Backup Handler with the given config
         /// </summary>
         /// <param name="config">The configuration the Handler will pull values from</param>
+        /// <param name="hostApplicationLifetime">The application lifetime to call shutdown on when user requests</param>
         /// <exception cref="ApplicationException">Thrown when the application is not configured correctly</exception>
         public BackupHandler(IConfiguration config, IHostApplicationLifetime hostApplicationLifetime)
         {
@@ -67,46 +74,12 @@ namespace CDDABackup
                     "Save directory has not been set! Please modify the appSettings.json to point 'saveDirectory' to your CDDA save directory.");
             }
         }
-
-        /// <summary>
-        /// Handler for when a file changes within a save directory
-        /// </summary>
-        /// <param name="sender">The event sender</param>
-        /// <param name="e">The event containing the file changed</param>
-        private void OnSaveChanged(object sender, FileSystemEventArgs e)
-        {
-            // Only mark actual saves
-            string path = e.FullPath;
-            if (path == this.backupDirectoryPath)
-            {
-                return;
-            }
-
-            // Note the time we saw this update
-            lastWritten[path] = DateTime.Now;
-        }
-
-        /// <summary>
-        /// Takes a given directory and writes an exact copy of all of its contents to the backup directory, recursively.
-        /// </summary>
-        /// <param name="sourceDirectory">The original Directory to Copy</param>
-        /// <param name="backupDirectory">The destination of the Copy</param>
-        private void BackupFolder(DirectoryInfo sourceDirectory, DirectoryInfo backupDirectory)
-        {
-            // Backup all the files
-            foreach (var file in sourceDirectory.GetFiles())
-            {
-                file.CopyTo(Path.Combine(backupDirectory.FullName, file.Name));
-            }
-
-            // Backup all the Directories
-            foreach (var directory in sourceDirectory.GetDirectories())
-            {
-                // Recursion isn't ideal but I highly doubt this will ever be nested enough to stack overflow
-                this.BackupFolder(directory, backupDirectory.CreateSubdirectory(directory.Name));
-            }
-        }
         
+        /// <summary>
+        /// Run the main backup tasks until cancelled
+        /// </summary>
+        /// <param name="stoppingToken">The token that the Handler will watch for when it should stop</param>
+        /// <returns>Indefinite backup task that only stops once the token has been cancelled</returns>
         private async Task RunBackups(CancellationToken stoppingToken)
         {
             try
@@ -175,7 +148,50 @@ namespace CDDABackup
             }
         }
 
-        protected  override async Task ExecuteAsync(CancellationToken stoppingToken)
+        /// <summary>
+        /// Handler for when a file changes within a save directory
+        /// </summary>
+        /// <param name="sender">The event sender</param>
+        /// <param name="e">The event containing the file changed</param>
+        private void OnSaveChanged(object sender, FileSystemEventArgs e)
+        {
+            // Only mark actual saves
+            string path = e.FullPath;
+            if (path == this.backupDirectoryPath)
+            {
+                return;
+            }
+
+            // Note the time we saw this update
+            lastWritten[path] = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Takes a given directory and writes an exact copy of all of its contents to the backup directory, recursively.
+        /// </summary>
+        /// <param name="sourceDirectory">The original Directory to Copy</param>
+        /// <param name="backupDirectory">The destination of the Copy</param>
+        private void BackupFolder(DirectoryInfo sourceDirectory, DirectoryInfo backupDirectory)
+        {
+            // Backup all the files
+            foreach (var file in sourceDirectory.GetFiles())
+            {
+                file.CopyTo(Path.Combine(backupDirectory.FullName, file.Name));
+            }
+
+            // Backup all the Directories
+            foreach (var directory in sourceDirectory.GetDirectories())
+            {
+                // Recursion isn't ideal but I highly doubt this will ever be nested enough to stack overflow
+                this.BackupFolder(directory, backupDirectory.CreateSubdirectory(directory.Name));
+            }
+        }
+        
+        /// <summary>
+        /// Wraps the backup task with control logic
+        /// </summary>
+        /// <param name="stoppingToken">The application wide stopping token</param>
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             // Write out fluffy intro
             Console.WriteLine("[CDDA Backup Tool]");
@@ -195,7 +211,6 @@ namespace CDDABackup
                     this.RunBackups(stoppingToken)
                 )
             );
-            
             
             Console.WriteLine("done");
         }

--- a/CDDABackup/CDDABackup.csproj
+++ b/CDDABackup/CDDABackup.csproj
@@ -16,6 +16,12 @@
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+      <PackageReference Include="Serilog" Version="2.10.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+      <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     </ItemGroup>
 
 </Project>

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -1,50 +1,37 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
 
 namespace CDDABackup
 {
-    /// <summary>
-    /// Contains the entry point to the application and any bootstrap logic
-    ///
-    /// Driven entirely by the settings in appSettings.json
-    /// </summary>
-    class Program
+    public class Program
     {
-        /// <summary>
-        /// Main entry point to the program
-        /// </summary>
-        /// <returns>Task that upon completion the application haas ended</returns>
         static async Task Main()
         {
-            // Log out fluffy intro
-            Console.WriteLine("[CDDA Backup Tool]");
-            Console.WriteLine("----------------");
-            Console.WriteLine("Press any key to stop.");
-            
-            // Build Handler
-            BackupHandler handler = new BackupHandler(Program.buildConfig());
-
-            // Run two tasks, one to catch the user Input to cancel and one to actually run the handler
-            CancellationTokenSource cts = new CancellationTokenSource();
-            await Task.WhenAll(
-                Task.Run(() =>
-                {
-                    Console.ReadKey();
-                    Console.WriteLine();
-                    Console.WriteLine("Shutting Down...");
-                    cts.Cancel();
-                }),
-                handler.RunAsync(cts.Token)
-            );
+            await Program.CreateHostBuilder().RunConsoleAsync();
         }
-        
-        static IConfigurationRoot buildConfig()
+
+        private static IHostBuilder CreateHostBuilder()
         {
-            var builder = new ConfigurationBuilder();
-            builder.AddJsonFile("appSettings.json", false, false);
-            return builder.Build();
+            return new HostBuilder()
+                .ConfigureAppConfiguration(builder =>
+                {
+                    builder.AddJsonFile("appSettings.json");
+                })
+                .ConfigureServices((services) =>
+                    {
+                        services
+                            // Specify the class that is the app/service that should be ran.
+                            .AddHostedService<BackupHandler>();
+                    }
+                ).ConfigureLogging((hostContext, logging) =>
+                {
+                    ILogger logger =
+                        new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration).CreateLogger();
+                    logging.AddSerilog(logger);
+                });
         }
     }
 }

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -6,13 +6,26 @@ using Serilog;
 
 namespace CDDABackup
 {
+    /// <summary>
+    /// Contains the entry point to the application and any bootstrap logic
+    ///
+    /// Driven entirely by the settings in appSettings.json
+    /// </summary>
     public class Program
     {
+        /// <summary>
+        /// Main entry point to the program
+        /// </summary>
+        /// <returns>Task that upon completion the application haas ended</returns>
         static async Task Main()
         {
             await Program.CreateHostBuilder().RunConsoleAsync();
         }
-
+        
+        /// <summary>
+        /// Configures/builds the entire applications main service, including config, DI and logging
+        /// </summary>
+        /// <returns>The configured Host Builder ready for use</returns>
         private static IHostBuilder CreateHostBuilder()
         {
             return new HostBuilder()

--- a/CDDABackup/appSettings.json
+++ b/CDDABackup/appSettings.json
@@ -5,5 +5,22 @@
     "timestampFormat": "yyyy-MM-dd HH-mm-ss",
     "saveGracePeriodMilliseconds": 5000,
     "timeBetweenUpdatesMilliseconds": 1000
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning"
+      }
+    },
+    "WriteTo": {
+      "File": {
+        "Name": "File",
+        "Args": {
+          "path": "./debug-log.txt",
+          "outputTemplate": "{Level:u4}|{Timestamp:yyyy-MM-dd HH:mm:ss}|{SourceContext}|{Message:lj}{NewLine}"
+        }
+      }
+    }
   }
 }

--- a/CDDABackup/appSettings.json
+++ b/CDDABackup/appSettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "CDDABackup": {
-    "saveDirectory": "",
+    "saveDirectory": "D:\\Cataclysm\\CDDA Game Launcher\\cdda\\save",
     "backupFolderName": "CDDABackups",
     "timestampFormat": "yyyy-MM-dd HH-mm-ss",
     "saveGracePeriodMilliseconds": 5000,


### PR DESCRIPTION
# Problem

I wanted to add file logging via Serilog and I am not happy with Serilog's suggestions to use a static logger as it goes against SOLID.

This means it needs to be correctly built in as part of the application, similar to how it would work in a ASP.NET project. Luckily, we can utilise the same kind of approach.

# Solution

- Add in various dependencies to give us a HostBuilder with the available extensions for Configuration, Logging and Depdency Injection.
- Convert the old `Program.cs` file to run as a `BackgroundService`
- Change the way Configuration is created to now be app wide
- Add an app wide DI container
- Add an app wide Logger that comes from a configuration driven Serilog
- Run the application via the `RuneConsoleAsync` task.