### PR TITLE
Refactor to isolate save monitoring functionality

### DIFF
--- a/CDDABackup/BackupHandler.cs
+++ b/CDDABackup/BackupHandler.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using Serilog;
 
 namespace CDDABackup
 {
@@ -34,18 +31,19 @@ namespace CDDABackup
         /// <summary>
         /// The Application control so we can gracefully request shutdown via user input
         /// </summary>
-        private IHostApplicationLifetime hostApplicationLifetime;
+        private readonly IHostApplicationLifetime hostApplicationLifetime;
 
         /// <summary>
         /// The Save Watcher utilised to trigger when a backup should happen
         /// </summary>
-        private SaveWatcher saveWatcher;
+        private readonly SaveWatcher saveWatcher;
 
         /// <summary>
         /// Creates a new Backup Handler with the given config
         /// </summary>
         /// <param name="config">The configuration the Handler will pull values from</param>
         /// <param name="hostApplicationLifetime">The application lifetime to call shutdown on when user requests</param>
+        /// <param name="saveWatcher">The Watcher that will be used to detect when a backup should be made</param>
         /// <exception cref="ApplicationException">Thrown when the application is not configured correctly</exception>
         public BackupHandler(IConfiguration config, IHostApplicationLifetime hostApplicationLifetime, SaveWatcher saveWatcher)
         {

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,7 +22,7 @@ namespace CDDABackup
         {
             await Program.CreateHostBuilder().RunConsoleAsync();
         }
-        
+
         /// <summary>
         /// Configures/builds the entire applications main service, including config, DI and logging
         /// </summary>
@@ -29,17 +30,17 @@ namespace CDDABackup
         private static IHostBuilder CreateHostBuilder()
         {
             return new HostBuilder()
-                .ConfigureAppConfiguration(builder =>
-                {
-                    builder.AddJsonFile("appSettings.json");
-                })
+                .ConfigureAppConfiguration(builder => { builder.AddJsonFile("appSettings.json"); })
                 .ConfigureServices((services) =>
                     {
                         services
-                            // Specify the class that is the app/service that should be ran.
-                            .AddHostedService<BackupHandler>();
+                            // Run CDDA  core as a background service
+                            .AddHostedService<BackupHandler>()
+                            .AddTransient<SaveWatcher>()
+                            .AddOptions<ScummerSettings>().BindConfiguration("CDDABackup");
                     }
-                ).ConfigureLogging((hostContext, logging) =>
+                )
+                .ConfigureLogging((hostContext, logging) =>
                 {
                     ILogger logger =
                         new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration).CreateLogger();

--- a/CDDABackup/SaveWatcher.cs
+++ b/CDDABackup/SaveWatcher.cs
@@ -40,10 +40,11 @@ namespace CDDABackup
         }
 
         /// <summary>
-        /// Runs the SaveWatcher until cancelled
+        /// Runs the SaveWatcher until cancelled, triggering the passed in callback whenever a save changes
         /// </summary>
         /// <param name="stoppingToken">The token to cancel the execution</param>
-        public async Task WatchFilesAsync(CancellationToken stoppingToken, Action<string> onSave)
+        /// <param name="onSaveChanged">Action to call upon a Save change being detected, passing in the name of the save</param>
+        public async Task WatchFilesAsync(CancellationToken stoppingToken, Action<string> onSaveChanged)
         {
             var dirWatcher = new FileSystemWatcher(this.settings.SaveDirectory)
             {
@@ -72,7 +73,7 @@ namespace CDDABackup
 
                     // trigger the event
                     this.logger.LogDebug($"Triggering OnSaveChanged: {save}");
-                    onSave(save);
+                    onSaveChanged(save);
 
                     // Mark the save as handled
                     savesHandled.Add(save);

--- a/CDDABackup/SaveWatcher.cs
+++ b/CDDABackup/SaveWatcher.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CDDABackup
+{
+    /// <summary>
+    /// Class responsible for monitoring the save directory and triggering events when required
+    /// </summary>
+    public class SaveWatcher
+    {
+        /// <summary>
+        /// The settings used for the Save Watcher
+        /// </summary>
+        private readonly ScummerSettings settings;
+
+        /// <summary>
+        /// The logger used by the SaveWatcher
+        /// </summary>
+        private readonly ILogger<SaveWatcher> logger;
+
+        /// <summary>
+        /// Lookup for the last time a folder (the key) was modified (the value), used to control when to fire OnSaveChanged
+        /// </summary>
+        private readonly Dictionary<string, DateTime> lastSaveUpdate = new();
+
+        /// <summary>
+        /// Builds a new SaveWatcher with the given dependencies
+        /// </summary>
+        /// <param name="settings">The settings the SaveWatcher will use to configure itself</param>
+        /// <param name="logger">The logger the SaveWatcher will write to</param>
+        public SaveWatcher(IOptions<ScummerSettings> settings, ILogger<SaveWatcher> logger)
+        {
+            this.settings = settings.Value;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Runs the SaveWatcher until cancelled
+        /// </summary>
+        /// <param name="stoppingToken">The token to cancel the execution</param>
+        public async Task WatchFilesAsync(CancellationToken stoppingToken, Action<string> onSave)
+        {
+            var dirWatcher = new FileSystemWatcher(this.settings.SaveDirectory)
+            {
+                NotifyFilter = NotifyFilters.LastWrite,
+                EnableRaisingEvents = true
+            };
+
+            dirWatcher.Changed += this.OnFileChanged;
+            dirWatcher.Error += (sender, args) =>
+            {
+                this.logger.LogError(args.GetException(), "Inner Exception thrown in FileWatcher");
+            };
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                HashSet<string> savesHandled = new();
+                foreach (var (save, date) in this.lastSaveUpdate)
+                {
+                    // Make sure save has finished writing before copying or we'll get half the save
+                    DateTime now = DateTime.Now;
+                    if (now - date < TimeSpan.FromMilliseconds(this.settings.SaveGracePeriodMilliseconds))
+                    {
+                        this.logger.LogTrace($"Skipped save due to grace period: {save}");
+                        continue;
+                    }
+
+                    // trigger the event
+                    this.logger.LogDebug($"Triggering OnSaveChanged: {save}");
+                    onSave(save);
+
+                    // Mark the save as handled
+                    savesHandled.Add(save);
+                }
+
+                // Remove any saves that were processed
+                foreach (string save in savesHandled)
+                {
+                    this.logger.LogTrace($"Marking save as processed {save}");
+                    this.lastSaveUpdate.Remove(save);
+                }
+
+                // Avoid throttling when no work is required
+                await Task.Delay(this.settings.TimeBetweenUpdatesMilliseconds, stoppingToken);
+            }
+        }
+
+        /// <summary>
+        /// Handler for when a file changes within a save directory
+        /// </summary>
+        /// <param name="sender">The event sender</param>
+        /// <param name="e">The event containing the file changed</param>
+        private void OnFileChanged(object sender, FileSystemEventArgs e)
+        {
+            // Only mark actual saves
+            string path = e.FullPath;
+            if (path == this.settings.BackupDirectory)
+            {
+                this.logger.LogTrace($"Skipped backup directory: {path}");
+                return;
+            }
+
+            // Note the time we saw this update
+            this.lastSaveUpdate[path] = DateTime.Now;
+            this.logger.LogTrace($"Marked save as seen: {path}");
+        }
+    }
+}

--- a/CDDABackup/ScummerSettings.cs
+++ b/CDDABackup/ScummerSettings.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace CDDABackup
+{
+    public class ScummerSettings
+    {
+        public string SaveDirectory { get; set; }
+        public string BackupFolderName { get; set; }
+        public string BackupDirectory => Path.Combine(this.SaveDirectory, this.BackupFolderName);
+        public string TimestampFormat { get; set; }
+        public int SaveGracePeriodMilliseconds { get; set; }
+        public int TimeBetweenUpdatesMilliseconds { get; set; }
+    }
+}

--- a/CDDABackup/ScummerSettings.cs
+++ b/CDDABackup/ScummerSettings.cs
@@ -2,13 +2,40 @@
 
 namespace CDDABackup
 {
+    /// <summary>
+    /// Options for configuring the Save Scummer
+    /// </summary>
     public class ScummerSettings
     {
+        /// <summary>
+        /// The Directory that the game saves exist in, used to watch for changes and the folders to backup
+        /// </summary>
         public string SaveDirectory { get; set; }
+        
+        /// <summary>
+        /// The name of the folder that will be created to store backups inside
+        /// </summary>
         public string BackupFolderName { get; set; }
+        
+        /// <summary>
+        /// The Directory in which the backups will be located
+        /// </summary>
         public string BackupDirectory => Path.Combine(this.SaveDirectory, this.BackupFolderName);
+        
+        /// <summary>
+        /// The DateTime format that will be used when naming the backup
+        /// </summary>
         public string TimestampFormat { get; set; }
+        
+        /// <summary>
+        /// The delay in milliseconds after a save changes before the backup happens. Used as a single save change causes
+        /// many events, so there needs to be some time to pass to wait for all parts of the save to have been written
+        /// </summary>
         public int SaveGracePeriodMilliseconds { get; set; }
+        
+        /// <summary>
+        /// How often in milliseconds the Scummer will check to see if it needs to write a backup
+        /// </summary>
         public int TimeBetweenUpdatesMilliseconds { get; set; }
     }
 }

--- a/CDDABackup/appSettings.json
+++ b/CDDABackup/appSettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "CDDABackup": {
-    "saveDirectory": "D:\\Cataclysm\\CDDA Game Launcher\\cdda\\save",
+    "saveDirectory": "",
     "backupFolderName": "CDDABackups",
     "timestampFormat": "yyyy-MM-dd HH-mm-ss",
     "saveGracePeriodMilliseconds": 5000,
@@ -17,7 +17,7 @@
       "File": {
         "Name": "File",
         "Args": {
-          "path": "./debug-log.txt",
+          "path": "./debug-log.log",
           "outputTemplate": "{Level:u4}|{Timestamp:yyyy-MM-dd HH:mm:ss}|{SourceContext}|{Message:lj}{NewLine}"
         }
       }


### PR DESCRIPTION
# Problem

As this was written so quickly, a lot of the code lives in one single class. This is messy and makes it harder to maintain going forwards as there are blurred lines around responsibilities and the general scope ends up bloated.

# Solution

As a first step, the logic around when to trigger a backup has been moved out to it's own class that is only responsible for watching the save directory and notifying when a save has changed. This have moved all the grace period handling, what paths to watch and trigger for, etc, to it's own layer. Allowing the backup layer to be simplified.

As a bonus, I also ported the config to use `IOptions` and sections. This allows cleaner/easier passing of config, as well as supporting further changes such as config validation.
