### PR TITLE
Refactor Backup Writing to be its own class

### DIFF
--- a/CDDABackup/BackupHandler.cs
+++ b/CDDABackup/BackupHandler.cs
@@ -52,10 +52,7 @@ namespace CDDABackup
         {
             try
             {
-                await this.saveWatcher.WatchFilesAsync(stoppingToken, save =>
-                {
-                    this.backupWriter.BackupSave(save);
-                });
+                await this.saveWatcher.WatchFilesAsync(stoppingToken, this.backupWriter.BackupSave);
             }
             catch (Exception e)
             {

--- a/CDDABackup/BackupHandler.cs
+++ b/CDDABackup/BackupHandler.cs
@@ -15,21 +15,6 @@ namespace CDDABackup
     public class BackupHandler : BackgroundService
     {
         /// <summary>
-        /// The core CDDA directory where saves are written to
-        /// </summary>
-        private readonly string saveDirectory;
-
-        /// <summary>
-        /// The directory path that backups are saved to
-        /// </summary>
-        private readonly string backupDirectoryPath;
-
-        /// <summary>
-        /// The timestamp format to attach to each backup
-        /// </summary>
-        private readonly string timestampFormat;
-        
-        /// <summary>
         /// The Application control so we can gracefully request shutdown via user input
         /// </summary>
         private readonly IHostApplicationLifetime hostApplicationLifetime;
@@ -40,36 +25,22 @@ namespace CDDABackup
         private readonly SaveWatcher saveWatcher;
 
         /// <summary>
-        /// The copier to use to actually create the backup files
+        /// The Backup Writer utilised to actually write backups
         /// </summary>
-        private readonly Copier fileCopier;
+        private readonly BackupWriter backupWriter;
 
         /// <summary>
         /// Creates a new Backup Handler with the given config
         /// </summary>
-        /// <param name="config">The configuration the Handler will pull values from</param>
         /// <param name="hostApplicationLifetime">The application lifetime to call shutdown on when user requests</param>
         /// <param name="saveWatcher">The Watcher that will be used to detect when a backup should be made</param>
-        /// <param name="copier">The Copier that the Handler will use to copy files with</param>
+        /// <param name="backupWriter">The Backup Writer that the Handler will use to make backups</param>
         /// <exception cref="ApplicationException">Thrown when the application is not configured correctly</exception>
-        public BackupHandler(IConfiguration config, IHostApplicationLifetime hostApplicationLifetime, SaveWatcher saveWatcher, Copier copier)
+        public BackupHandler(IHostApplicationLifetime hostApplicationLifetime, SaveWatcher saveWatcher, BackupWriter backupWriter)
         {
             this.hostApplicationLifetime = hostApplicationLifetime;
-            
-            // Configure Handler
-            this.saveDirectory = config["CDDABackup:saveDirectory"];
-            this.backupDirectoryPath = saveDirectory + "\\" + config["CDDABackup:backupFolderName"];
-            this.timestampFormat = config["CDDABackup:timestampFormat"];
-            
-            // Check for invalid configuration
-            if (this.saveDirectory.Length == 0)
-            {
-                throw new ApplicationException(
-                    "Save directory has not been set! Please modify the appSettings.json to point 'saveDirectory' to your CDDA save directory.");
-            }
-
             this.saveWatcher = saveWatcher;
-            this.fileCopier = copier;
+            this.backupWriter = backupWriter;
         }
         
         /// <summary>
@@ -81,28 +52,9 @@ namespace CDDABackup
         {
             try
             {
-                // Ensure backup directory exists
-                Directory.CreateDirectory(this.backupDirectoryPath);
-
-                await saveWatcher.WatchFilesAsync(stoppingToken, save =>
+                await this.saveWatcher.WatchFilesAsync(stoppingToken, save =>
                 {
-                    // Save has changed, back up time.
-                    DirectoryInfo sourceDirectory = new DirectoryInfo(save);
-                    
-                    // Build the Backup Name/Path
-                    DateTime now = DateTime.Now;
-                    string saveName = sourceDirectory.Name;
-                    string backupName = $"{saveName} {now.ToString(timestampFormat)}";
-                    string backupPath = Path.Combine(this.backupDirectoryPath, backupName);
-                    
-                    // Do the backup
-                    this.fileCopier.CopyDirectory(sourceDirectory, backupPath);
-
-                    // Zip it up and remove unzipped version
-                    ZipFile.CreateFromDirectory(backupPath, backupPath + ".zip", CompressionLevel.Optimal, false);
-                    Directory.Delete(backupPath, true);
-
-                    Console.WriteLine($"Wrote backup: {backupPath + ".zip"}");
+                    this.backupWriter.BackupSave(save);
                 });
             }
             catch (Exception e)

--- a/CDDABackup/BackupWriter.cs
+++ b/CDDABackup/BackupWriter.cs
@@ -44,6 +44,10 @@ namespace CDDABackup
             Directory.CreateDirectory(this.settings.BackupDirectory);
         }
 
+        /// <summary>
+        /// Makes a backup of the given save
+        /// </summary>
+        /// <param name="save">The save to backup</param>
         public void BackupSave(string save)
         {
             // Grab the Save Directory

--- a/CDDABackup/BackupWriter.cs
+++ b/CDDABackup/BackupWriter.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using CDDABackup.FileHandling;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CDDABackup
+{
+    /// <summary>
+    /// Responsible for actually writing backups
+    /// </summary>
+    public class BackupWriter
+    {
+        /// <summary>
+        /// The logger the backup writer will write to
+        /// </summary>
+        /// <returns></returns>
+        private readonly ILogger<BackupWriter> logger;
+        
+        /// <summary>
+        /// The settings used to configure the Writer
+        /// </summary>
+        private readonly ScummerSettings settings;
+
+        /// <summary>
+        /// The file copier used to actually write the backups
+        /// </summary>
+        private readonly Copier copier;
+
+        /// <summary>
+        /// Creates a new Backup Writer with the given settings
+        /// </summary>
+        /// <param name="logger">The logger the backup writer will log to</param>
+        /// <param name="settings">The settings to use</param>
+        /// <param name="copier">The copier for doing the actual backup</param>
+        public BackupWriter(ILogger<BackupWriter> logger, IOptions<ScummerSettings> settings, Copier copier)
+        {
+            this.logger = logger;
+            this.settings = settings.Value;
+            this.copier = copier;
+            
+            // Ensure backup directory exists
+            Directory.CreateDirectory(this.settings.BackupDirectory);
+        }
+
+        public void BackupSave(string save)
+        {
+            // Grab the Save Directory
+            DirectoryInfo saveDirectory = new DirectoryInfo(save);
+            
+            // Build the Backup Name/Path
+            DateTime now = DateTime.Now;
+            string backupName = $"{saveDirectory.Name} {now.ToString(this.settings.TimestampFormat)}";
+            string backupPath = Path.Combine(this.settings.BackupDirectory, backupName);
+            
+            // Do the backup
+            this.logger.LogTrace($"Making backup of {saveDirectory} to {backupPath}");
+            this.copier.CopyDirectory(saveDirectory, backupPath);
+            
+            // Zip it up and remove unzipped version
+            this.logger.LogTrace($"Compressing unzipped backup: {backupPath}");
+            ZipFile.CreateFromDirectory(backupPath, backupPath + ".zip", CompressionLevel.Optimal, false);
+            
+            this.logger.LogTrace($"Deleting unzipped backup: {backupPath}");
+            Directory.Delete(backupPath, true);
+            
+            this.logger.LogInformation($"Wrote backup: {backupPath + ".zip"}");
+        }
+    }
+}

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -38,6 +38,7 @@ namespace CDDABackup
                             .AddHostedService<BackupHandler>()
                             .AddTransient<SaveWatcher>()
                             .AddSingleton<Copier>()
+                            .AddSingleton<BackupWriter>()
                             .AddOptions<ScummerSettings>().BindConfiguration("CDDABackup");
                     }
                 )

--- a/CDDABackup/SaveWatcher.cs
+++ b/CDDABackup/SaveWatcher.cs
@@ -53,7 +53,7 @@ namespace CDDABackup
             };
 
             dirWatcher.Changed += this.OnFileChanged;
-            dirWatcher.Error += (sender, args) =>
+            dirWatcher.Error += (_, args) =>
             {
                 this.logger.LogError(args.GetException(), "Inner Exception thrown in FileWatcher");
             };


### PR DESCRIPTION
# Problem

All the Backup writing, path finding, directory creation, etc, currently happens in the main app loop. This could be moved to its own class.

# Solution

Move the backup handling logic to its own class and inject it in.