### PR TITLE
Covert Dependency setup to Extension method

### DIFF
--- a/CDDABackup/CDDAExtensions.cs
+++ b/CDDABackup/CDDAExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.CompilerServices;
+using CDDABackup.FileHandling;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CDDABackup
+{
+    // Extension Method hold
+    public static class CDDAExtensions
+    {
+        /// <summary>
+        /// Extend Service Collection to add helper method to add just CDDA dependencies
+        /// </summary>
+        /// <param name="container">The container to add dependecies to</param>
+        /// <returns>The container for method chaining</returns>
+        public static IServiceCollection AddCDDA(this IServiceCollection container)
+        {
+            container.AddHostedService<BackupHandler>()
+                .AddTransient<SaveWatcher>()
+                .AddSingleton<Copier>()
+                .AddSingleton<BackupWriter>()
+                .AddOptions<ScummerSettings>().BindConfiguration("CDDABackup");
+
+            return container;
+        }
+    }
+}

--- a/CDDABackup/CDDAExtensions.cs
+++ b/CDDABackup/CDDAExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using CDDABackup.FileHandling;
+﻿using CDDABackup.FileHandling;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CDDABackup

--- a/CDDABackup/CDDAExtensions.cs
+++ b/CDDABackup/CDDAExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CDDABackup
 {
-    // Extension Method hold
+    // Class for CDDA related extensions
     public static class CDDAExtensions
     {
         /// <summary>

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System.Threading.Tasks;
-using CDDABackup.FileHandling;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 

--- a/CDDABackup/Program.cs
+++ b/CDDABackup/Program.cs
@@ -33,13 +33,7 @@ namespace CDDABackup
                 .ConfigureAppConfiguration(builder => { builder.AddJsonFile("appSettings.json"); })
                 .ConfigureServices((services) =>
                     {
-                        services
-                            // Run CDDA  core as a background service
-                            .AddHostedService<BackupHandler>()
-                            .AddTransient<SaveWatcher>()
-                            .AddSingleton<Copier>()
-                            .AddSingleton<BackupWriter>()
-                            .AddOptions<ScummerSettings>().BindConfiguration("CDDABackup");
+                        services.AddCDDA();
                     }
                 )
                 .ConfigureLogging((hostContext, logging) =>


### PR DESCRIPTION
# Problem

Service container set up can bloat to be a huge ugly mess with no clear boundaries.

# Solution

Use an extension method to hide away the DI for this service. Adding/splitting more methods in the future when required.